### PR TITLE
Reduce webrtc dependency to a single one

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,7 @@ libp2p-gossipsub = { version = "0.40.0", path = "protocols/gossipsub", optional 
 # TODO: use upstream once Protocol for WebRTC is there.
 [patch.crates-io]
 multiaddr = { version = "0.14.0", git = "https://github.com/melekes/rust-multiaddr.git", branch = "anton/x-webrtc" }
-webrtc-data = { version = "0.4.0", git = "https://github.com/webrtc-rs/data.git" }
+webrtc = { version = "0.4.0", git = "https://github.com/webrtc-rs/webrtc.git", rev = "8a570f2b650daac7e4455cc3d9ae094c56fbe037" }
 
 [dev-dependencies]
 async-std = { version = "1.6.2", features = ["attributes"] }

--- a/transports/webrtc/Cargo.toml
+++ b/transports/webrtc/Cargo.toml
@@ -28,11 +28,7 @@ stun = "0.4"
 thiserror = "1"
 tinytemplate = "1.2"
 tokio-crate = { package = "tokio", version = "1.18", features = ["net"]}
-webrtc = { version = "0.4.0", git = "https://github.com/webrtc-rs/webrtc.git" }
-webrtc-data = { version = "0.4.0", git = "https://github.com/webrtc-rs/data.git" }
-webrtc-ice = "0.7.0"
-webrtc-sctp = "0.5.0"
-webrtc-util = { version = "0.5.4", default-features = false, features = ["conn", "vnet", "sync"] }
+webrtc = "0.4.0"
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/transports/webrtc/src/connection.rs
+++ b/transports/webrtc/src/connection.rs
@@ -31,9 +31,9 @@ use futures::{
 use futures_lite::StreamExt;
 use libp2p_core::{muxing::StreamMuxer, Multiaddr};
 use log::{debug, error, trace};
+use webrtc::data::data_channel::DataChannel as DetachedDataChannel;
 use webrtc::data_channel::RTCDataChannel;
 use webrtc::peer_connection::RTCPeerConnection;
-use webrtc_data::data_channel::DataChannel as DetachedDataChannel;
 
 use std::{
     pin::Pin,

--- a/transports/webrtc/src/connection/poll_data_channel.rs
+++ b/transports/webrtc/src/connection/poll_data_channel.rs
@@ -19,8 +19,8 @@
 // DEALINGS IN THE SOFTWARE.
 
 use futures::prelude::*;
-use webrtc_data::data_channel::DataChannel;
-use webrtc_data::data_channel::PollDataChannel as RTCPollDataChannel;
+use webrtc::data::data_channel::DataChannel;
+use webrtc::data::data_channel::PollDataChannel as RTCPollDataChannel;
 
 use std::io;
 use std::pin::Pin;

--- a/transports/webrtc/src/transport.rs
+++ b/transports/webrtc/src/transport.rs
@@ -38,9 +38,9 @@ use libp2p_core::{
 use libp2p_noise::{Keypair, NoiseConfig, NoiseError, RemoteIdentity, X25519Spec};
 use log::{debug, trace};
 use tokio_crate::net::UdpSocket;
+use webrtc::ice::udp_mux::UDPMux;
 use webrtc::peer_connection::certificate::RTCCertificate;
 use webrtc::peer_connection::configuration::RTCConfiguration;
-use webrtc_ice::udp_mux::UDPMux;
 
 use std::{
     borrow::Cow,

--- a/transports/webrtc/src/udp_mux.rs
+++ b/transports/webrtc/src/udp_mux.rs
@@ -28,8 +28,8 @@ use stun::{
 };
 use tokio::{io::ReadBuf, net::UdpSocket};
 use tokio_crate as tokio;
-use webrtc_ice::udp_mux::{UDPMux, UDPMuxConn, UDPMuxConnParams, UDPMuxWriter};
-use webrtc_util::{sync::RwLock, Conn, Error};
+use webrtc::ice::udp_mux::{UDPMux, UDPMuxConn, UDPMuxConnParams, UDPMuxWriter};
+use webrtc::util::{sync::RwLock, Conn, Error};
 
 use std::{
     collections::{HashMap, HashSet},

--- a/transports/webrtc/src/webrtc_connection.rs
+++ b/transports/webrtc/src/webrtc_connection.rs
@@ -25,15 +25,15 @@ use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 use webrtc::api::setting_engine::SettingEngine;
 use webrtc::api::APIBuilder;
+use webrtc::data::data_channel::DataChannel;
 use webrtc::data_channel::data_channel_init::RTCDataChannelInit;
 use webrtc::dtls_transport::dtls_role::DTLSRole;
+use webrtc::ice::network_type::NetworkType;
+use webrtc::ice::udp_mux::UDPMux;
+use webrtc::ice::udp_network::UDPNetwork;
 use webrtc::peer_connection::configuration::RTCConfiguration;
 use webrtc::peer_connection::sdp::session_description::RTCSessionDescription;
 use webrtc::peer_connection::RTCPeerConnection;
-use webrtc_data::data_channel::DataChannel;
-use webrtc_ice::network_type::NetworkType;
-use webrtc_ice::udp_mux::UDPMux;
-use webrtc_ice::udp_network::UDPNetwork;
 
 use std::{net::SocketAddr, sync::Arc, time::Duration};
 


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->

Depending on the recent webrtc master branch breaks a couple of things because of the move to the monorepo I assume. To ensure CI stability of our dev branch, we pin the dependency to a specific hash. At the same time, depending on the various subcrates may result in mismatching versions. To avoid this, we remove those dependencies and import the modules via the re-export from the root `webrtc` crate.

## Links to any relevant issues

<!-- Reference any related issues.-->


## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
