### PR TITLE
transports/webrtc: Implement deterministic certificates generation

### DIFF
--- a/transports/webrtc/Cargo.toml
+++ b/transports/webrtc/Cargo.toml
@@ -25,7 +25,7 @@ pem = "1.1.0"
 prost = "0.11"
 prost-codec = { version = "0.2.1", path = "../../misc/prost-codec" }
 rand = "0.8"
-ring = "0.16.20"
+ring = { git = "https://github.com/briansmith/ring", features = ["std"], rev = "abe9529fc063f575759f8166bba02db171a3a0f6" }
 rustls = "0.19.1" # Must match version in webrtc library.
 serde = { version = "1.0", features = ["derive"] }
 simple_x509 = "0.2.2"
@@ -34,7 +34,8 @@ thiserror = "1"
 tinytemplate = "1.2"
 tokio = { version = "1.18", features = ["net"], optional = true}
 tokio-util = { version = "0.7", features = ["compat"], optional = true }
-webrtc = { version = "0.5.0", optional = true }
+# webrtc = { version = "0.5.0", optional = true }
+webrtc = { git = "https://github.com/thomaseizinger/webrtc", optional = true, rev = "dc8d896784eb7ba8f5cecc2e5ae2917bb16c0c65" }
 
 [features]
 tokio = ["dep:tokio", "dep:tokio-util", "dep:webrtc"]

--- a/transports/webrtc/Cargo.toml
+++ b/transports/webrtc/Cargo.toml
@@ -24,6 +24,8 @@ multihash = { version = "0.16", default-features = false, features = ["sha2"] }
 prost = "0.11"
 prost-codec = { version = "0.2.1", path = "../../misc/prost-codec" }
 rand = "0.8"
+rcgen = "0.9.3"
+ring = "0.16.20"
 serde = { version = "1.0", features = ["derive"] }
 stun = "0.4"
 thiserror = "1"
@@ -43,5 +45,9 @@ anyhow = "1.0"
 env_logger = "0.9"
 hex-literal = "0.3"
 libp2p = { path = "../..", features = ["request-response", "webrtc"], default-features = false }
-rcgen = "0.9.3"
 unsigned-varint = { version = "0.7", features = ["asynchronous_codec"] }
+rand_chacha = "0.3.1"
+
+[[test]]
+name = "smoke"
+required-features = ["tokio"]

--- a/transports/webrtc/Cargo.toml
+++ b/transports/webrtc/Cargo.toml
@@ -21,12 +21,14 @@ libp2p-core = { version = "0.37.0", path = "../../core"  }
 libp2p-noise = { version = "0.40.0", path = "../../transports/noise" }
 log = "0.4"
 multihash = { version = "0.16", default-features = false, features = ["sha2"] }
+pem = "1.1.0"
 prost = "0.11"
 prost-codec = { version = "0.2.1", path = "../../misc/prost-codec" }
 rand = "0.8"
-rcgen = "0.9.3"
 ring = "0.16.20"
+rustls = "0.19.1" # Must match version in webrtc library.
 serde = { version = "1.0", features = ["derive"] }
+simple_x509 = "0.2.2"
 stun = "0.4"
 thiserror = "1"
 tinytemplate = "1.2"

--- a/transports/webrtc/Cargo.toml
+++ b/transports/webrtc/Cargo.toml
@@ -16,6 +16,7 @@ bytes = "1"
 futures = "0.3"
 futures-timer = "3"
 hex = "0.4"
+hkdf = "0.12.3"
 if-watch = "2.0"
 libp2p-core = { version = "0.37.0", path = "../../core"  }
 libp2p-noise = { version = "0.40.0", path = "../../transports/noise" }
@@ -25,9 +26,11 @@ pem = "1.1.0"
 prost = "0.11"
 prost-codec = { version = "0.2.1", path = "../../misc/prost-codec" }
 rand = "0.8"
+rand_chacha = "0.3.1"
 ring = { git = "https://github.com/briansmith/ring", features = ["std"], rev = "abe9529fc063f575759f8166bba02db171a3a0f6" }
 rustls = "0.19.1" # Must match version in webrtc library.
 serde = { version = "1.0", features = ["derive"] }
+sha2 = "0.10.6"
 simple_x509 = "=0.2.2" # Version MUST be pinned to ensure a patch-update doesn't accidentially break deterministic certs.
 stun = "0.4"
 thiserror = "1"

--- a/transports/webrtc/Cargo.toml
+++ b/transports/webrtc/Cargo.toml
@@ -28,7 +28,7 @@ rand = "0.8"
 ring = { git = "https://github.com/briansmith/ring", features = ["std"], rev = "abe9529fc063f575759f8166bba02db171a3a0f6" }
 rustls = "0.19.1" # Must match version in webrtc library.
 serde = { version = "1.0", features = ["derive"] }
-simple_x509 = "0.2.2"
+simple_x509 = "=0.2.2" # Version MUST be pinned to ensure a patch-update doesn't accidentially break deterministic certs.
 stun = "0.4"
 thiserror = "1"
 tinytemplate = "1.2"

--- a/transports/webrtc/src/tokio/certificate.rs
+++ b/transports/webrtc/src/tokio/certificate.rs
@@ -34,7 +34,6 @@ use std::time::{Duration, SystemTime};
 pub struct Certificate {
     inner: RTCCertificate,
 }
-
 impl Certificate {
     /// Generate new certificate.
     ///
@@ -54,10 +53,15 @@ impl Certificate {
                     serialized_der: key_pair_der_bytes,
                 },
             },
-            &pem::encode(&Pem {
-                tag: "CERTIFICATE".to_string(),
-                contents: certificate,
-            }),
+            &pem::encode_config(
+                &Pem {
+                    tag: "CERTIFICATE".to_string(),
+                    contents: certificate,
+                },
+                pem::EncodeConfig {
+                    line_ending: pem::LineEnding::LF,
+                },
+            ),
             expiry,
         );
 

--- a/transports/webrtc/src/tokio/certificate.rs
+++ b/transports/webrtc/src/tokio/certificate.rs
@@ -1,3 +1,23 @@
+// Copyright 2022 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
 use crate::tokio::fingerprint::Fingerprint;
 use pem::Pem;
 use rand::{CryptoRng, Rng};

--- a/transports/webrtc/src/tokio/certificate.rs
+++ b/transports/webrtc/src/tokio/certificate.rs
@@ -35,24 +35,6 @@ pub struct Certificate {
     inner: RTCCertificate,
 }
 
-/// The year 2000.
-const UNIX_2000: i64 = 946645200;
-
-/// The year 3000.
-const UNIX_3000: i64 = 32503640400;
-
-/// OID for the organisation name. See <http://oid-info.com/get/2.5.4.10>.
-const ORGANISATION_NAME_OID: [u64; 4] = [2, 5, 4, 10];
-
-/// OID for Elliptic Curve Public Key Cryptography. See <http://oid-info.com/get/1.2.840.10045.2.1>.
-const EC_OID: [u64; 6] = [1, 2, 840, 10045, 2, 1];
-
-/// OID for 256-bit Elliptic Curve Cryptography (ECC) with the P256 curve. See <http://oid-info.com/get/1.2.840.10045.3.1.7>.
-const P256_OID: [u64; 7] = [1, 2, 840, 10045, 3, 1, 7];
-
-/// OID for the ECDSA signature algorithm with using SHA256 as the hash function. See <http://oid-info.com/get/1.2.840.10045.4.3.2>.
-const ECDSA_SHA256_OID: [u64; 7] = [1, 2, 840, 10045, 4, 3, 2];
-
 impl Certificate {
     /// Generate new certificate.
     ///
@@ -110,6 +92,24 @@ impl Certificate {
         self.inner.clone()
     }
 }
+
+/// The year 2000.
+const UNIX_2000: i64 = 946645200;
+
+/// The year 3000.
+const UNIX_3000: i64 = 32503640400;
+
+/// OID for the organisation name. See <http://oid-info.com/get/2.5.4.10>.
+const ORGANISATION_NAME_OID: [u64; 4] = [2, 5, 4, 10];
+
+/// OID for Elliptic Curve Public Key Cryptography. See <http://oid-info.com/get/1.2.840.10045.2.1>.
+const EC_OID: [u64; 6] = [1, 2, 840, 10045, 2, 1];
+
+/// OID for 256-bit Elliptic Curve Cryptography (ECC) with the P256 curve. See <http://oid-info.com/get/1.2.840.10045.3.1.7>.
+const P256_OID: [u64; 7] = [1, 2, 840, 10045, 3, 1, 7];
+
+/// OID for the ECDSA signature algorithm with using SHA256 as the hash function. See <http://oid-info.com/get/1.2.840.10045.4.3.2>.
+const ECDSA_SHA256_OID: [u64; 7] = [1, 2, 840, 10045, 4, 3, 2];
 
 /// Create a deterministic ECDSA keypair from the provided randomness source.
 fn make_keypair<R>(rng: &mut R) -> Result<(EcdsaKeyPair, Vec<u8>), Kind>

--- a/transports/webrtc/src/tokio/certificate.rs
+++ b/transports/webrtc/src/tokio/certificate.rs
@@ -73,7 +73,7 @@ impl Certificate {
         let der_encoded = x509.x509_enc().ok_or(Kind::FailedToEncode)?;
 
         let certificate = webrtc::dtls::crypto::Certificate {
-            certificate: vec![rustls::Certificate(der_encoded)],
+            certificate: vec![rustls::Certificate(der_encoded.clone())],
             private_key: CryptoPrivateKey {
                 kind: CryptoPrivateKeyKind::Ecdsa256(key_pair),
                 serialized_der: document.as_ref().to_owned(),
@@ -84,7 +84,7 @@ impl Certificate {
             certificate,
             &pem::encode(&Pem {
                 tag: "CERTIFICATE".to_string(),
-                contents: document.as_ref().to_owned(),
+                contents: der_encoded,
             }),
             SystemTime::UNIX_EPOCH
                 .checked_add(Duration::from_secs(UNIX_3000 as u64))
@@ -147,7 +147,7 @@ mod tests {
 
         assert_eq!(
             pem,
-            "-----BEGIN CERTIFICATE-----\r\nMIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgdqBAU72gqIvaUXe4\r\nahXDsp9VmHPLSBIyKZzVdDFRrEuhRANCAARUpdAcrvL5Quijbk3jdtO3RxTerTIS\r\nRAp3fqP9w6+OyXDhnRuSFDV73UA6oW0PSnDvQnbYFMuQRe8ZUfZYTnWU\r\n-----END CERTIFICATE-----\r\n"
+            "-----BEGIN CERTIFICATE-----\r\nMIIBEDCBvgIBADAKBggqhkjOPQQDAjAWMRQwEgYDVQQKDAtydXN0LWxpYnAycDAi\r\nGA8xOTk5MTIzMTEzMDAwMFoYDzI5OTkxMjMxMTMwMDAwWjAWMRQwEgYDVQQKDAty\r\ndXN0LWxpYnAycDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABFSl0Byu8vlC6KNu\r\nTeN207dHFN6tMhJECnd+o/3Dr47JcOGdG5IUNXvdQDqhbQ9KcO9CdtgUy5BF7xlR\r\n9lhOdZQwCgYIKoZIzj0EAwIDQQBdpiGC3yxU6g+91aWxEfBPZF9WjQXRjysDUmzf\r\n5C4H1Ql1XNPpojRHPOrFnjYZwvolt2PxgFKEHYhZAIJBUyfy\r\n-----END CERTIFICATE-----\r\n"
         )
     }
 

--- a/transports/webrtc/src/tokio/certificate.rs
+++ b/transports/webrtc/src/tokio/certificate.rs
@@ -169,7 +169,7 @@ where
 
     let expiry = SystemTime::UNIX_EPOCH
         .checked_add(Duration::from_secs(UNIX_3000 as u64))
-        .expect("expiry to be always valid");
+        .expect("year 3000 to be representable by SystemTime");
 
     Ok((der_bytes, expiry))
 }

--- a/transports/webrtc/src/tokio/certificate.rs
+++ b/transports/webrtc/src/tokio/certificate.rs
@@ -164,7 +164,7 @@ where
         .sign_oid(Vec::from(ECDSA_SHA256_OID))
         .build()
         .sign(
-            |cert, _| Some(key_pair.sign(&rng, &cert).ok()?.as_ref().to_owned()),
+            |cert, _| Some(key_pair.sign(&rng, cert).ok()?.as_ref().to_owned()),
             &vec![], // We close over the keypair so no need to pass it.
         )
         .ok_or(Kind::FailedToSign)?;
@@ -251,7 +251,7 @@ mod tests {
     // must not change after that nodes has been deployed.
     #[test]
     fn certificate_snapshot_test() {
-        let rng = &mut ChaCha20Rng::from_seed([08; 32]);
+        let rng = &mut ChaCha20Rng::from_seed([0u8; 32]);
 
         let certificate = Certificate::generate(rng).unwrap();
 
@@ -260,10 +260,10 @@ mod tests {
             "-----BEGIN CERTIFICATE-----
 MIIBEDCBvgIBADAKBggqhkjOPQQDAjAWMRQwEgYDVQQKDAtydXN0LWxpYnAycDAi
 GA8xOTk5MTIzMTEzMDAwMFoYDzI5OTkxMjMxMTMwMDAwWjAWMRQwEgYDVQQKDAty
-dXN0LWxpYnAycDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABK34lOiIEUBnrKQr
-52CMEDJvW5zVbxE7IQjqGNlwXlJgIfCn55LvExE9csJ/9M29QbatMVfVk2D95grU
-PDugDCUwCgYIKoZIzj0EAwIDQQDnfjBoTLnV/rUqiTcvGlGI3ujrVpmceiBmUHEN
-NDkFfzGJualwH7xdNUUAzrEoJHWqN9r8U5BmpfO2QO9spKpR
+dXN0LWxpYnAycDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABFSl0Byu8vlC6KNu
+TeN207dHFN6tMhJECnd+o/3Dr47JcOGdG5IUNXvdQDqhbQ9KcO9CdtgUy5BF7xlR
+9lhOdZQwCgYIKoZIzj0EAwIDQQDJeZkXegzKY/HsmwGmwWkj5Ugb4xFRdShOws27
+w7KDep+YY9SzpA3Tb91I0F1sbkb1LR195V4lMsQ6Jhqm4Ex6
 -----END CERTIFICATE-----
 "
         )

--- a/transports/webrtc/src/tokio/certificate.rs
+++ b/transports/webrtc/src/tokio/certificate.rs
@@ -87,14 +87,14 @@ where
     R: CryptoRng + Rng,
 {
     let rng = FixedSliceSequenceRandom {
-        bytes: &[&rng.gen::<[u8; 32]>()],
+        bytes: &[&rng.gen::<[u8; 32]>(), &rng.gen::<[u8; 32]>()],
         current: UnsafeCell::new(0),
     };
 
     let document = EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &rng)?;
     let der_bytes = document.as_ref().to_owned();
 
-    let key_pair = EcdsaKeyPair::from_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &der_bytes)?;
+    let key_pair = EcdsaKeyPair::from_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &der_bytes, &rng)?;
 
     Ok((key_pair, der_bytes))
 }

--- a/transports/webrtc/src/tokio/certificate.rs
+++ b/transports/webrtc/src/tokio/certificate.rs
@@ -80,6 +80,12 @@ impl Certificate {
         Ok(Self { inner: certificate })
     }
 
+    /// Returns SHA-256 fingerprint of this certificate.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if there's no fingerprint with the SHA-256 algorithm (see
+    /// [`RTCCertificate::get_fingerprints`]).
     pub fn fingerprint(&self) -> Fingerprint {
         let fingerprints = self.inner.get_fingerprints().expect("to never fail");
         let sha256_fingerprint = fingerprints
@@ -90,6 +96,7 @@ impl Certificate {
         Fingerprint::try_from_rtc_dtls(sha256_fingerprint).expect("we filtered by sha-256")
     }
 
+    /// Returns this certificate in PEM format.
     pub fn to_pem(&self) -> &str {
         self.inner.pem()
     }
@@ -102,6 +109,7 @@ impl Certificate {
     }
 }
 
+/// Create a deterministic ECDSA keypair from the provided randomness source.
 fn make_keypair<R>(rng: &mut R) -> Result<(EcdsaKeyPair, Vec<u8>), Kind>
 where
     R: CryptoRng + Rng,

--- a/transports/webrtc/src/tokio/certificate.rs
+++ b/transports/webrtc/src/tokio/certificate.rs
@@ -229,6 +229,32 @@ mod tests {
         assert_eq!(key1.public_key().as_ref(), key2.public_key().as_ref());
     }
 
+    // YOU MUST NOT EVER CHANGE THE ASSERTION IN THIS TEST.
+    // THIS TEST FAILING MEANS YOU BROKE DETERMINISTIC CERTIFICATION GENERATION.
+    //
+    // libp2p essentially performs certificate pinning through the `/certhash` protocol
+    // in multiaddresses. Peers expect boot nodes to have a certain certificate hash which
+    // must not change after that nodes has been deployed.
+    #[test]
+    fn certificate_snapshot_test() {
+        let rng = &mut ChaCha20Rng::from_seed([08; 32]);
+
+        let certificate = Certificate::generate(rng).unwrap();
+
+        assert_eq!(
+            certificate.to_pem(),
+            "-----BEGIN CERTIFICATE-----
+MIIBEDCBvgIBADAKBggqhkjOPQQDAjAWMRQwEgYDVQQKDAtydXN0LWxpYnAycDAi
+GA8xOTk5MTIzMTEzMDAwMFoYDzI5OTkxMjMxMTMwMDAwWjAWMRQwEgYDVQQKDAty
+dXN0LWxpYnAycDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABK34lOiIEUBnrKQr
+52CMEDJvW5zVbxE7IQjqGNlwXlJgIfCn55LvExE9csJ/9M29QbatMVfVk2D95grU
+PDugDCUwCgYIKoZIzj0EAwIDQQDnfjBoTLnV/rUqiTcvGlGI3ujrVpmceiBmUHEN
+NDkFfzGJualwH7xdNUUAzrEoJHWqN9r8U5BmpfO2QO9spKpR
+-----END CERTIFICATE-----
+"
+        )
+    }
+
     #[test]
     fn cloned_certificate_is_equivalent() {
         let certificate = Certificate::generate(&mut thread_rng()).unwrap();

--- a/transports/webrtc/src/tokio/certificate.rs
+++ b/transports/webrtc/src/tokio/certificate.rs
@@ -38,6 +38,9 @@ pub struct Certificate {
     inner: RTCCertificate,
 }
 impl Certificate {
+    /// Derives a new certificate from the provided keypair.
+    ///
+    /// This derivation is pure and will yield the same certificate for the same keypair.
     pub fn new(identity: &identity::Keypair) -> Result<Self, CertificateError> {
         let ed25519_keypair = match identity {
             identity::Keypair::Ed25519(inner) => inner,

--- a/transports/webrtc/src/tokio/certificate.rs
+++ b/transports/webrtc/src/tokio/certificate.rs
@@ -189,15 +189,35 @@ mod tests {
 
     #[test]
     fn certificate_generation_is_deterministic() {
-        let (keypair1, _) = make_keypair(&mut ChaCha20Rng::from_seed([0u8; 32])).unwrap();
-        let (keypair2, _) = make_keypair(&mut ChaCha20Rng::from_seed([0u8; 32])).unwrap();
+        let keypair_seed = [0u8; 32];
+        let cert_seed = [1u8; 32];
+
+        let (keypair1, _) = make_keypair(&mut ChaCha20Rng::from_seed(keypair_seed)).unwrap();
+        let (keypair2, _) = make_keypair(&mut ChaCha20Rng::from_seed(keypair_seed)).unwrap();
 
         let (bytes1, _) =
-            make_minimal_certificate(&mut ChaCha20Rng::from_seed([1u8; 32]), &keypair1).unwrap();
+            make_minimal_certificate(&mut ChaCha20Rng::from_seed(cert_seed), &keypair1).unwrap();
         let (bytes2, _) =
-            make_minimal_certificate(&mut ChaCha20Rng::from_seed([1u8; 32]), &keypair2).unwrap();
+            make_minimal_certificate(&mut ChaCha20Rng::from_seed(cert_seed), &keypair2).unwrap();
 
         assert_eq!(bytes1, bytes2)
+    }
+
+    #[test]
+    fn different_seed_yields_different_certificate() {
+        let keypair_seed = [0u8; 32];
+        let cert1_seed = [1u8; 32];
+        let cert2_seed = [2u8; 32];
+
+        let (keypair1, _) = make_keypair(&mut ChaCha20Rng::from_seed(keypair_seed)).unwrap();
+        let (keypair2, _) = make_keypair(&mut ChaCha20Rng::from_seed(keypair_seed)).unwrap();
+
+        let (bytes1, _) =
+            make_minimal_certificate(&mut ChaCha20Rng::from_seed(cert1_seed), &keypair1).unwrap();
+        let (bytes2, _) =
+            make_minimal_certificate(&mut ChaCha20Rng::from_seed(cert2_seed), &keypair2).unwrap();
+
+        assert_ne!(bytes1, bytes2)
     }
 
     #[test]

--- a/transports/webrtc/src/tokio/certificate.rs
+++ b/transports/webrtc/src/tokio/certificate.rs
@@ -18,15 +18,17 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::tokio::fingerprint::Fingerprint;
 use pem::Pem;
 use rand::{CryptoRng, Rng};
 use ring::signature::{EcdsaKeyPair, KeyPair, ECDSA_P256_SHA256_FIXED_SIGNING};
 use ring::test::rand::FixedSliceSequenceRandom;
-use std::cell::UnsafeCell;
-use std::time::{Duration, SystemTime};
 use webrtc::dtls::crypto::{CryptoPrivateKey, CryptoPrivateKeyKind};
 use webrtc::peer_connection::certificate::RTCCertificate;
+
+use crate::tokio::fingerprint::Fingerprint;
+
+use std::cell::UnsafeCell;
+use std::time::{Duration, SystemTime};
 
 #[derive(Clone, PartialEq)]
 pub struct Certificate {

--- a/transports/webrtc/src/tokio/certificate.rs
+++ b/transports/webrtc/src/tokio/certificate.rs
@@ -1,0 +1,126 @@
+use crate::tokio::fingerprint::Fingerprint;
+use rand::distributions::DistString;
+use rand::{CryptoRng, Rng};
+use rcgen::{CertificateParams, RcgenError, PKCS_ED25519};
+use ring::signature::Ed25519KeyPair;
+use ring::test::rand::FixedSliceSequenceRandom;
+use std::cell::UnsafeCell;
+use webrtc::peer_connection::certificate::RTCCertificate;
+
+#[derive(Clone, PartialEq)]
+pub struct Certificate {
+    inner: RTCCertificate,
+}
+
+impl Certificate {
+    /// Generate new certificate.
+    ///
+    /// This function is pure and will generate the same certificate provided the exact same randomness source.
+    pub fn generate<R>(rng: &mut R) -> Result<Self, Error>
+    where
+        R: CryptoRng + Rng,
+    {
+        let keypair = new_keypair(rng)?;
+        let alt_name = rand::distributions::Alphanumeric.sample_string(rng, 16);
+
+        let mut params = CertificateParams::new(vec![alt_name.clone()]);
+        params.alg = &PKCS_ED25519;
+        params.key_pair = Some(keypair);
+
+        let certificate = RTCCertificate::from_params(params).map_err(Kind::WebRTC)?;
+
+        Ok(Self { inner: certificate })
+    }
+
+    pub fn fingerprint(&self) -> Fingerprint {
+        let fingerprints = self.inner.get_fingerprints().expect("to never fail");
+        let sha256_fingerprint = fingerprints
+            .iter()
+            .find(|f| f.algorithm == "sha-256")
+            .expect("a SHA-256 fingerprint");
+
+        Fingerprint::try_from_rtc_dtls(sha256_fingerprint).expect("we filtered by sha-256")
+    }
+
+    pub fn to_pem(&self) -> &str {
+        self.inner.pem()
+    }
+
+    /// Extract the [`RTCCertificate`] from this wrapper.
+    ///
+    /// This function is `pub(crate)` to avoid leaking the `webrtc` dependency to our users.
+    pub(crate) fn to_rtc_certificate(&self) -> RTCCertificate {
+        self.inner.clone()
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+#[error("Failed to generate certificate")]
+pub struct Error(#[from] Kind);
+
+#[derive(thiserror::Error, Debug)]
+enum Kind {
+    #[error(transparent)]
+    Rcgen(RcgenError),
+    #[error(transparent)]
+    Ring(ring::error::Unspecified),
+    #[error(transparent)]
+    WebRTC(webrtc::Error),
+}
+
+/// Generates a new [`rcgen::KeyPair`] from the given randomness source.
+///
+/// This implementation uses `ring`'s [`FixedSliceSequenceRandom`] to create a deterministic randomness
+/// source which allows us to fully control the resulting keypair.
+///
+/// [`FixedSliceSequenceRandom`] only hands out the provided byte-slices for each call to
+/// [`SecureRandom::fill`] and therefore does not offer ANY guarantees about the randomess, it is
+/// all under our control.
+///
+/// Using [`FixedSliceSequenceRandom`] over [`FixedSliceRandom`] ensures that we only ever use the
+/// provided byte-slice once and don't reuse our "randomness" for different variables which could be
+/// a security problem.
+fn new_keypair<R>(rng: &mut R) -> Result<rcgen::KeyPair, Error>
+where
+    R: CryptoRng + Rng,
+{
+    let ring_rng = FixedSliceSequenceRandom {
+        bytes: &[&rng.gen::<[u8; 32]>()],
+        current: UnsafeCell::new(0),
+    };
+
+    let document = Ed25519KeyPair::generate_pkcs8(&ring_rng).map_err(Kind::Ring)?;
+    let der = document.as_ref();
+    let keypair = rcgen::KeyPair::from_der(der).map_err(Kind::Rcgen)?;
+
+    Ok(keypair)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::thread_rng;
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha20Rng;
+
+    #[test]
+    fn certificate_generation_is_deterministic() {
+        let certificate = Certificate::generate(&mut ChaCha20Rng::from_seed([0u8; 32])).unwrap();
+
+        let pem = certificate.to_pem();
+
+        assert_eq!(
+            pem,
+            "-----BEGIN CERTIFICATE-----\r\nMIIBGTCBzKADAgECAgkA349L+6JmEFgwBQYDK2VwMCExHzAdBgNVBAMMFnJjZ2Vu\r\nIHNlbGYgc2lnbmVkIGNlcnQwIBcNNzUwMTAxMDAwMDAwWhgPNDA5NjAxMDEwMDAw\r\nMDBaMCExHzAdBgNVBAMMFnJjZ2VuIHNlbGYgc2lnbmVkIGNlcnQwKjAFBgMrZXAD\r\nIQDqCj9zLT7ijKUXLEZw7/JZeuDEvleLkSgyFN3Q8lhWXqMfMB0wGwYDVR0RBBQw\r\nEoIQNTRDZG14TlhhREhFd1k4VzAFBgMrZXADQQBQdGOd+rpYKM63TTDT7V4TysD3\r\nhSD7qs2fNQ+tM7mGe9r2mScaOXvnoCnlLt/wDsEB3hFwpkmRbgZMLjCooZ8E\r\n-----END CERTIFICATE-----\r\n"
+        )
+    }
+
+    #[test]
+    fn cloned_certificate_is_equivalent() {
+        let certificate = Certificate::generate(&mut thread_rng()).unwrap();
+
+        let cloned_certificate = certificate.clone();
+
+        assert!(certificate == cloned_certificate)
+    }
+}

--- a/transports/webrtc/src/tokio/mod.rs
+++ b/transports/webrtc/src/tokio/mod.rs
@@ -18,7 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-pub mod certificate;
+mod certificate;
 mod connection;
 mod error;
 mod fingerprint;
@@ -29,7 +29,7 @@ mod transport;
 mod udp_mux;
 mod upgrade;
 
-pub use certificate::Certificate;
+pub use certificate::CertificateError;
 pub use connection::Connection;
 pub use error::Error;
 pub use transport::Transport;

--- a/transports/webrtc/src/tokio/mod.rs
+++ b/transports/webrtc/src/tokio/mod.rs
@@ -18,6 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+pub mod certificate;
 mod connection;
 mod error;
 mod fingerprint;
@@ -28,6 +29,7 @@ mod transport;
 mod udp_mux;
 mod upgrade;
 
+pub use certificate::Certificate;
 pub use connection::Connection;
 pub use error::Error;
 pub use transport::Transport;

--- a/transports/webrtc/src/tokio/transport.rs
+++ b/transports/webrtc/src/tokio/transport.rs
@@ -338,11 +338,6 @@ struct Config {
 
 impl Config {
     /// Returns a new [`Config`] with the given keys and certificate.
-    ///
-    /// # Panics
-    ///
-    /// This function will panic if there's no fingerprint with the SHA-256 algorithm (see
-    /// [`RTCCertificate::get_fingerprints`]).
     fn new(id_keys: identity::Keypair, certificate: Certificate) -> Self {
         let fingerprint = certificate.fingerprint();
 

--- a/transports/webrtc/tests/smoke.rs
+++ b/transports/webrtc/tests/smoke.rs
@@ -32,7 +32,7 @@ use libp2p::request_response::{
 };
 use libp2p::swarm::{Swarm, SwarmBuilder, SwarmEvent};
 use libp2p::webrtc::tokio as webrtc;
-use rand::{thread_rng, RngCore};
+use rand::RngCore;
 
 use std::{io, iter};
 
@@ -470,10 +470,7 @@ impl RequestResponseCodec for PingCodec {
 fn create_swarm() -> Result<Swarm<RequestResponse<PingCodec>>> {
     let id_keys = identity::Keypair::generate_ed25519();
     let peer_id = id_keys.public().to_peer_id();
-    let transport = webrtc::Transport::new(
-        id_keys,
-        webrtc::Certificate::generate(&mut thread_rng()).unwrap(),
-    );
+    let transport = webrtc::Transport::new(id_keys)?;
 
     let protocols = iter::once((PingProtocol(), ProtocolSupport::Full));
     let cfg = RequestResponseConfig::default();

--- a/transports/webrtc/tests/smoke.rs
+++ b/transports/webrtc/tests/smoke.rs
@@ -33,6 +33,7 @@ use libp2p::request_response::{
 use libp2p::swarm::{Swarm, SwarmBuilder, SwarmEvent};
 use libp2p::webrtc::tokio as webrtc;
 use rand::{thread_rng, RngCore};
+
 use std::{io, iter};
 
 #[tokio::test]


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->

This PR implements deterministic certificate generation by means of `ring` and the `simple_x509` library.

Closes https://github.com/libp2p/rust-libp2p/issues/3049.

## Links to any relevant issues

<!-- Reference any related issues.-->


## Open tasks

- https://github.com/rustls/rcgen/pull/166
- https://github.com/webrtc-rs/webrtc/pull/335

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
